### PR TITLE
🔨 ImportOp should support XML/HTML mode

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -37,7 +37,7 @@ jobs:
       - name: Set up Go
         uses: actions/setup-go@d35c59abb061a4a6fb18e82ac0862c26744d6ab5 # v5.5.0
         with:
-          go-version: '1.24.2'
+          go-version: '1.25'
 
       - name: Install lint tools
         run: |

--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -34,7 +34,7 @@ jobs:
       - name: Set up Go
         uses: actions/setup-go@d35c59abb061a4a6fb18e82ac0862c26744d6ab5 # v5.5.0
         with:
-          go-version: '1.24'
+          go-version: '1.25'
 
       - name: Run GoReleaser
         uses: goreleaser/goreleaser-action@e435ccd777264be153ace6237001ef4d979d3a7a # v6.4.0

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -23,10 +23,10 @@ repos:
         args:
           - --autofix
           - --indent=2
-  - repo: https://github.com/golangci/golangci-lint
-    rev: v2.4.0
-    hooks:
-      - id: golangci-lint
+#  - repo: https://github.com/golangci/golangci-lint
+#    rev: 3641f1c8f5bf57447e805d22484247748e3776aa
+#    hooks:
+#      - id: golangci-lint
   - repo: https://github.com/dnephin/pre-commit-golang
     rev: v0.5.1
     hooks:

--- a/go.mod
+++ b/go.mod
@@ -14,7 +14,7 @@
 
 module github.com/rkosegi/yaml-pipeline
 
-go 1.24.2
+go 1.25.0
 
 replace github.com/chenzhuoyu/iasm v0.9.0 => github.com/cloudwego/iasm v0.2.0
 

--- a/go.mod
+++ b/go.mod
@@ -26,7 +26,7 @@ require (
 	github.com/gookit/color v1.5.4
 	github.com/kaptinlin/jsonschema v0.4.6
 	github.com/rkosegi/slog-config v0.0.0-20250720232421-a7890a122727
-	github.com/rkosegi/yaml-toolkit v1.0.67-0.20250825222828-a4a0d2e6cc63
+	github.com/rkosegi/yaml-toolkit v1.0.67-0.20250827043247-b58b24e36c03
 	github.com/samber/lo v1.51.0
 	github.com/spf13/cobra v1.9.1
 	github.com/stretchr/testify v1.11.0

--- a/go.mod
+++ b/go.mod
@@ -26,7 +26,7 @@ require (
 	github.com/gookit/color v1.5.4
 	github.com/kaptinlin/jsonschema v0.4.6
 	github.com/rkosegi/slog-config v0.0.0-20250720232421-a7890a122727
-	github.com/rkosegi/yaml-toolkit v1.0.67-0.20250808201420-56924b241fb7
+	github.com/rkosegi/yaml-toolkit v1.0.67-0.20250825222828-a4a0d2e6cc63
 	github.com/samber/lo v1.51.0
 	github.com/spf13/cobra v1.9.1
 	github.com/stretchr/testify v1.11.0

--- a/go.sum
+++ b/go.sum
@@ -125,8 +125,8 @@ github.com/prometheus/common v0.65.0 h1:QDwzd+G1twt//Kwj/Ww6E9FQq1iVMmODnILtW1t2
 github.com/prometheus/common v0.65.0/go.mod h1:0gZns+BLRQ3V6NdaerOhMbwwRbNh9hkGINtQAsP5GS8=
 github.com/rkosegi/slog-config v0.0.0-20250720232421-a7890a122727 h1:IUQppkCK2wtcMYlVkV2TyccG/AvTJPtFDLbqE0q388A=
 github.com/rkosegi/slog-config v0.0.0-20250720232421-a7890a122727/go.mod h1:xTuExV9uQT7qUjKiMer+PQbQ0ac7jxqLxFEvYd2q4ag=
-github.com/rkosegi/yaml-toolkit v1.0.67-0.20250808201420-56924b241fb7 h1:eQqdymUnYv3jjwLcX4E0nhRXC6rzBDGkucLUKx3F8x0=
-github.com/rkosegi/yaml-toolkit v1.0.67-0.20250808201420-56924b241fb7/go.mod h1:qu8qDPKfsC+i1SfaRgy/1q7DvO5zizkZBjOCbFas/HU=
+github.com/rkosegi/yaml-toolkit v1.0.67-0.20250825222828-a4a0d2e6cc63 h1:EglEI4UtROP4w9pMKN37b0gXlHlBHcQLaiHkyHxsFto=
+github.com/rkosegi/yaml-toolkit v1.0.67-0.20250825222828-a4a0d2e6cc63/go.mod h1:qu8qDPKfsC+i1SfaRgy/1q7DvO5zizkZBjOCbFas/HU=
 github.com/rogpeppe/go-internal v1.12.0 h1:exVL4IDcn6na9z1rAb56Vxr+CgyK3nn3O+epU5NdKM8=
 github.com/rogpeppe/go-internal v1.12.0/go.mod h1:E+RYuTGaKKdloAfM02xzb0FW3Paa99yedzYV+kq4uf4=
 github.com/russross/blackfriday/v2 v2.1.0/go.mod h1:+Rmxgy9KzJVeS9/2gXHxylqXiyQDYRxCVz55jmeOWTM=

--- a/go.sum
+++ b/go.sum
@@ -125,8 +125,8 @@ github.com/prometheus/common v0.65.0 h1:QDwzd+G1twt//Kwj/Ww6E9FQq1iVMmODnILtW1t2
 github.com/prometheus/common v0.65.0/go.mod h1:0gZns+BLRQ3V6NdaerOhMbwwRbNh9hkGINtQAsP5GS8=
 github.com/rkosegi/slog-config v0.0.0-20250720232421-a7890a122727 h1:IUQppkCK2wtcMYlVkV2TyccG/AvTJPtFDLbqE0q388A=
 github.com/rkosegi/slog-config v0.0.0-20250720232421-a7890a122727/go.mod h1:xTuExV9uQT7qUjKiMer+PQbQ0ac7jxqLxFEvYd2q4ag=
-github.com/rkosegi/yaml-toolkit v1.0.67-0.20250825222828-a4a0d2e6cc63 h1:EglEI4UtROP4w9pMKN37b0gXlHlBHcQLaiHkyHxsFto=
-github.com/rkosegi/yaml-toolkit v1.0.67-0.20250825222828-a4a0d2e6cc63/go.mod h1:qu8qDPKfsC+i1SfaRgy/1q7DvO5zizkZBjOCbFas/HU=
+github.com/rkosegi/yaml-toolkit v1.0.67-0.20250827043247-b58b24e36c03 h1:oohoexn5YxZnDRB9UWVF26X3NIbugwu/c5yaaLkF5qA=
+github.com/rkosegi/yaml-toolkit v1.0.67-0.20250827043247-b58b24e36c03/go.mod h1:tnjpLKdhNmsfRZ23UxaEHEQg2f03O8cDjea2YTxmYdA=
 github.com/rogpeppe/go-internal v1.12.0 h1:exVL4IDcn6na9z1rAb56Vxr+CgyK3nn3O+epU5NdKM8=
 github.com/rogpeppe/go-internal v1.12.0/go.mod h1:E+RYuTGaKKdloAfM02xzb0FW3Paa99yedzYV+kq4uf4=
 github.com/russross/blackfriday/v2 v2.1.0/go.mod h1:+Rmxgy9KzJVeS9/2gXHxylqXiyQDYRxCVz55jmeOWTM=

--- a/pkg/pipeline/html2dom.go
+++ b/pkg/pipeline/html2dom.go
@@ -84,7 +84,7 @@ func (x *Html2DomOpSpec) Do(ctx ActionContext) error {
 	// TODO: how can parse return an error?
 	srcNode, _ = htmlquery.Parse(&buff)
 	if len(qry) == 0 {
-		qry = "//html"
+		qry = "/html"
 	}
 	srcNode, err = htmlquery.Query(srcNode, qry)
 	if err != nil {

--- a/pkg/pipeline/import_op_test.go
+++ b/pkg/pipeline/import_op_test.go
@@ -28,90 +28,160 @@ func TestExecuteImportOp(t *testing.T) {
 		is ImportOpSpec
 		gd dom.ContainerBuilder
 	)
-	gd = dom.ContainerNode()
-	is = ImportOpSpec{
-		File: "../../testdata/doc1.json",
-		Path: "step1.data",
-		Mode: ParseFileModeJson,
-	}
+	t.Run("import valid JSON", func(t *testing.T) {
+		gd = dom.ContainerNode()
+		is = ImportOpSpec{
+			File: "../../testdata/doc1.json",
+			Path: "step1.data",
+			Mode: ParseFileModeJson,
+		}
 
-	assert.NoError(t, New(WithData(gd)).Execute(&is))
-	assert.Equal(t, "c", gd.Lookup("step1.data.root.list1[2]").AsLeaf().Value())
+		assert.NoError(t, New(WithData(gd)).Execute(&is))
+		assert.Equal(t, "c", gd.Lookup("step1.data.root.list1[2]").AsLeaf().Value())
+	})
 
-	// parsing YAML file as JSON should lead to error
-	is = ImportOpSpec{
-		File: "../testdata/doc1.yaml",
-		Mode: ParseFileModeJson,
-	}
-	assert.Error(t, New(WithData(gd)).Execute(&is))
+	t.Run("parsing YAML file as JSON should lead to error", func(t *testing.T) {
+		is = ImportOpSpec{
+			File: "../testdata/doc1.yaml",
+			Mode: ParseFileModeJson,
+		}
+		assert.Error(t, New().Execute(&is))
+	})
 
-	gd = dom.ContainerNode()
-	is = ImportOpSpec{
-		File: "../../testdata/doc1.yaml",
-		Mode: ParseFileModeYaml,
-		Path: "step1.data",
-	}
-	assert.NoError(t, New(WithData(gd)).Execute(&is))
-	assert.Equal(t, 456, gd.Lookup("step1.data.level1.level2a.level3b").AsLeaf().Value())
+	t.Run("import YAML into specific path", func(t *testing.T) {
+		gd = dom.ContainerNode()
+		is = ImportOpSpec{
+			File: "../../testdata/doc1.yaml",
+			Mode: ParseFileModeYaml,
+			Path: "step1.data",
+		}
+		assert.NoError(t, New(WithData(gd)).Execute(&is))
+		assert.Equal(t, 456, gd.Lookup("step1.data.level1.level2a.level3b").AsLeaf().Value())
+	})
 
-	gd = dom.ContainerNode()
-	is = ImportOpSpec{
-		File: "../../testdata/doc1.yaml",
-		Mode: ParseFileModeText,
-		Path: "step3",
-	}
-	assert.NoError(t, New(WithData(gd)).Execute(&is))
-	assert.NotEmpty(t, gd.Lookup("step3").AsLeaf().Value())
-	assert.Contains(t, is.String(), "path=step3,mode=text")
+	t.Run("import text file into specific path", func(t *testing.T) {
+		gd = dom.ContainerNode()
+		is = ImportOpSpec{
+			File: "../../testdata/doc1.yaml",
+			Mode: ParseFileModeText,
+			Path: "step3",
+		}
+		assert.NoError(t, New(WithData(gd)).Execute(&is))
+		assert.NotEmpty(t, gd.Lookup("step3").AsLeaf().Value())
+		assert.Contains(t, is.String(), "path=step3,mode=text")
+	})
 
-	gd = dom.ContainerNode()
-	is = ImportOpSpec{
-		File: "../../testdata/doc1.yaml",
-		Mode: ParseFileModeBinary,
-		Path: "files.doc1",
-	}
-	assert.NoError(t, New(WithData(gd)).Execute(&is))
-	assert.NotEmpty(t, gd.Lookup("files.doc1").AsLeaf().Value())
+	t.Run("import YAML document as binary file file into specific path", func(t *testing.T) {
+		gd = dom.ContainerNode()
+		is = ImportOpSpec{
+			File: "../../testdata/doc1.yaml",
+			Mode: ParseFileModeBinary,
+			Path: "files.doc1",
+		}
+		assert.NoError(t, New(WithData(gd)).Execute(&is))
+		assert.NotEmpty(t, gd.Lookup("files.doc1").AsLeaf().Value())
+	})
 
-	gd = dom.ContainerNode()
-	is = ImportOpSpec{
-		File: "../../testdata/doc1.json",
-		Path: "files.doc1_json",
-	}
-	assert.NoError(t, New(WithData(gd)).Execute(&is))
-	assert.Contains(t, is.String(), "path=files.doc1_json,mode=")
+	t.Run("import JSON document in default mode", func(t *testing.T) {
+		is = ImportOpSpec{
+			File: "../../testdata/doc1.json",
+			Path: "files.doc1_json",
+		}
+		assert.NoError(t, New().Execute(&is))
+		assert.Contains(t, is.String(), "path=files.doc1_json,mode=")
+	})
 
-	is = ImportOpSpec{
-		File: "non-existent-file.ext",
-		Path: "something",
-	}
-	assert.Error(t, New(WithData(gd)).Execute(&is))
+	t.Run("attempt to import non-existent file", func(t *testing.T) {
+		is = ImportOpSpec{
+			File: "non-existent-file.ext",
+			Path: "something",
+		}
+		assert.Error(t, New().Execute(&is))
+	})
 
-	is = ImportOpSpec{
-		File: "../../testdata/props1.properties",
-		Mode: ParseFileModeProperties,
-		Path: "props",
-	}
-	assert.NoError(t, New(WithData(gd)).Execute(&is))
+	t.Run("import properties file into specific path", func(t *testing.T) {
+		is = ImportOpSpec{
+			File: "../../testdata/props1.properties",
+			Mode: ParseFileModeProperties,
+			Path: "props",
+		}
+		assert.NoError(t, New().Execute(&is))
+	})
 
-	// no path provided and data is not a container - error
-	is = ImportOpSpec{
-		File: "../../testdata/props1.properties",
-		Mode: ParseFileModeText,
-	}
-	assert.Error(t, New(WithData(gd)).Execute(&is))
+	t.Run("import text into root (empty path) should fail", func(t *testing.T) {
+		is = ImportOpSpec{
+			File: "../../testdata/props1.properties",
+			Mode: ParseFileModeText,
+		}
+		assert.Error(t, New().Execute(&is))
+	})
 
-	// import directly to root (with no path)
-	is = ImportOpSpec{
-		File: "../../testdata/doc1.json",
-		Mode: ParseFileModeJson,
-	}
-	assert.NoError(t, New(WithData(gd)).Execute(&is))
+	t.Run("import JSON document directly to root (no path)", func(t *testing.T) {
+		is = ImportOpSpec{
+			File: "../../testdata/doc1.json",
+			Mode: ParseFileModeJson,
+		}
+		assert.NoError(t, New().Execute(&is))
+	})
 
-	is = ImportOpSpec{
-		File: "../../testdata/props1.properties",
-		Path: "something",
-		Mode: "invalid-mode",
-	}
-	assert.Error(t, New(WithData(gd)).Execute(&is))
+	t.Run("import using invalid mode should fail", func(t *testing.T) {
+		is = ImportOpSpec{
+			File: "../../testdata/props1.properties",
+			Path: "something",
+			Mode: "invalid-mode",
+		}
+		assert.Error(t, New().Execute(&is))
+	})
+
+	t.Run("import valid XML/HTML", func(t *testing.T) {
+		is = ImportOpSpec{
+			File: "../../testdata/doc1.html",
+			Mode: ParseFileModeXml,
+		}
+		assert.NoError(t, New().Execute(&is))
+	})
+
+	t.Run("import XML/HTML with invalid xpath should fail", func(t *testing.T) {
+		is = ImportOpSpec{
+			File: "../../testdata/doc1.html",
+			Mode: ParseFileModeXml,
+			Xml: &XmlImportOptions{
+				Query: &ValOrRef{Val: "////bad"},
+			},
+		}
+		assert.Error(t, New().Execute(&is))
+	})
+
+	t.Run("import XML/HTML with invalid layout should fail", func(t *testing.T) {
+		is = ImportOpSpec{
+			File: "../../testdata/doc1.html",
+			Mode: ParseFileModeXml,
+			Xml: &XmlImportOptions{
+				Layout: ptr(XmlLayout("invalid")),
+			},
+		}
+		assert.Error(t, New(WithData(gd)).Execute(&is))
+	})
+
+	t.Run("import XML/HTML with empty query should fallback to /html", func(t *testing.T) {
+		is = ImportOpSpec{
+			File: "../../testdata/doc1.html",
+			Mode: ParseFileModeXml,
+			Xml: &XmlImportOptions{
+				Query: &ValOrRef{Ref: "non.existing"},
+			},
+		}
+		assert.NoError(t, New().Execute(&is))
+	})
+
+	t.Run("import XML/HTML with non-resolvable query should fail", func(t *testing.T) {
+		is = ImportOpSpec{
+			File: "../../testdata/doc1.html",
+			Mode: ParseFileModeXml,
+			Xml: &XmlImportOptions{
+				Query: &ValOrRef{Val: "/this/does/not/work"},
+			},
+		}
+		assert.Error(t, New(WithData(dom.ContainerNode())).Execute(&is))
+	})
 }

--- a/pkg/pipeline/misc_types.go
+++ b/pkg/pipeline/misc_types.go
@@ -69,6 +69,15 @@ func (pv *ValOrRef) CloneWith(ctx ActionContext) *ValOrRef {
 	}
 }
 
+func (pv *ValOrRef) MarshalYAML() (interface{}, error) {
+	if len(pv.Ref) > 0 {
+		return map[string]interface{}{
+			"ref": pv.Ref,
+		}, nil
+	}
+	return pv.Val, nil
+}
+
 func (pv *ValOrRef) UnmarshalYAML(node *yaml.Node) error {
 	switch node.Kind {
 	case yaml.MappingNode:

--- a/pkg/pipeline/misc_types_test.go
+++ b/pkg/pipeline/misc_types_test.go
@@ -1,0 +1,46 @@
+/*
+Copyright 2025 Richard Kosegi
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package pipeline
+
+import (
+	"bytes"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"gopkg.in/yaml.v3"
+)
+
+func TestValOrRefMarshalYaml(t *testing.T) {
+	t.Run("Marshal ref", func(t *testing.T) {
+		var (
+			out  bytes.Buffer
+			node yaml.Node
+		)
+		assert.NoError(t, yaml.NewEncoder(&out).Encode(&ValOrRef{Ref: "path.to.elem"}))
+		assert.NoError(t, yaml.NewDecoder(&out).Decode(&node))
+		assert.Equal(t, yaml.MappingNode, node.Content[0].Kind)
+	})
+	t.Run("Marshal direct value", func(t *testing.T) {
+		var (
+			out  bytes.Buffer
+			node yaml.Node
+		)
+		assert.NoError(t, yaml.NewEncoder(&out).Encode(&ValOrRef{Val: "abc"}))
+		assert.NoError(t, yaml.NewDecoder(&out).Decode(&node))
+		assert.Equal(t, yaml.ScalarNode, node.Content[0].Kind)
+	})
+}

--- a/pkg/pipeline/types_test.go
+++ b/pkg/pipeline/types_test.go
@@ -37,7 +37,7 @@ func TestAnyVal(t *testing.T) {
 	d1 := `v: 123`
 	err = yaml.Unmarshal([]byte(d1), &ts)
 	assert.NoError(t, err)
-	assert.Equal(t, "123", ts.V.Value().AsLeaf().Value())
+	assert.Equal(t, 123, ts.V.Value().AsLeaf().Value())
 	d2 := `
 v:
   a: 123
@@ -45,7 +45,7 @@ v:
 `
 	err = yaml.Unmarshal([]byte(d2), &ts)
 	assert.NoError(t, err)
-	assert.Equal(t, "123", ts.V.Value().AsContainer().Child("a").AsLeaf().Value())
+	assert.Equal(t, 123, ts.V.Value().AsContainer().Child("a").AsLeaf().Value())
 }
 
 func TestValOrRef(t *testing.T) {

--- a/schemas/generator.patch.yaml
+++ b/schemas/generator.patch.yaml
@@ -38,6 +38,10 @@ components:
       properties:
         query:
           x-go-type: ValOrRef
+    xmlImportOptions:
+      properties:
+        query:
+          x-go-type: ValOrRef
     patchOpSpec:
       properties:
         value:

--- a/schemas/pipeline.json
+++ b/schemas/pipeline.json
@@ -246,6 +246,7 @@
       "type": "string"
     },
     "html2DomOpSpec": {
+      "description": "Allow for conversion of XML/HTML source DOM tree.\nThis is now deprecated and ImportOp with XML mode should be used instead.",
       "properties": {
         "from": {
           "description": "path within the global data to the leaf node where XML source is stored as string",
@@ -282,6 +283,10 @@
         "path": {
           "description": "Path at which to import the data.",
           "type": "string"
+        },
+        "xml": {
+          "$ref": "#/$defs/xmlImportOptions",
+          "description": "XML/HTML loading options"
         }
       },
       "required": [
@@ -410,11 +415,12 @@
       "type": "string"
     },
     "parseFileMode": {
-      "description": "ParseFileMode defines how the file is parsed before is put into data tree\n * binary - File is read and encoded using base64 string into data tree\n * text - File is read as-is and is assumed it represents utf-8 encoded byte stream\n * yaml - File is parsed as YAML document and put as child node into data tree\n * json - File is parsed as JSON document and put as child node into data tree\n * properties - File is parsed as Java properties into map[string]interface{} and put as child node into data tree",
+      "description": "ParseFileMode defines how the file is parsed before is put into data tree\n * binary - File is read and encoded using base64 string into data tree\n * text - File is read as-is and is assumed it represents utf-8 encoded byte stream\n * yaml - File is parsed as YAML document and put as child node into data tree\n * xml - File is parsed as XML document and transformed using selected layout.\n * json - File is parsed as JSON document and put as child node into data tree\n * properties - File is parsed as Java properties into map[string]interface{} and put as child node into data tree",
       "enum": [
         "binary",
         "text",
         "yaml",
+        "xml",
         "json",
         "properties"
       ],
@@ -568,6 +574,26 @@
         "path"
       ],
       "type": "object"
+    },
+    "xmlImportOptions": {
+      "description": "Configuration to customize XML loading. Only relevant for 'xml' mode",
+      "properties": {
+        "layout": {
+          "$ref": "#/$defs/xmlLayout",
+          "description": "layout defines how XML/HTML data are put into DOM"
+        },
+        "query": {
+          "description": "xpath expression to use to extract subset from source XML document. When omitted, then \"/html\" is assumed",
+          "type": "string"
+        }
+      }
+    },
+    "xmlLayout": {
+      "description": "Layout defines how XML-specific constructs are laid out into DOM tree.\n * default - will produce \"Value\" leaf for each text node.\n Child elements are collected into the list, if their name appears multiple times within the parent, otherwise they are regular child node.\n Attributes of element are put into container node \"Attrs\".\n Namespaces are ignored.",
+      "enum": [
+        "default"
+      ],
+      "type": "string"
     }
   },
   "$id": "https://github.com/rkosegi/yaml-pipeline/schemas/pipeline",


### PR DESCRIPTION
- **👷 Use head of golangci-lint repo until new release**
- **⬆️  Update github.com/rkosegi/yaml-toolkit to v1.0.67-0.20250825222828-a4a0d2e6cc63**
- **🔨 ValOrRef should implement MarshalYAML()**
- **🔨 ImportOp should support XML/HTML mode**
