### PR TITLE
✨TE: Add function uuidv4FromHex

### DIFF
--- a/pkg/pipeline/template_engine/template_engine.go
+++ b/pkg/pipeline/template_engine/template_engine.go
@@ -48,6 +48,7 @@ var defFuncs = template.FuncMap{
 	"sizeStrFmt":          sizeStrFmtFunc,
 	"sizeStrFmtLong":      sizeStrFmtLongFunc,
 	"deterministicUUIDv4": deterministicUUIDv4,
+	"uuidv4FromHex":       uuidv4FromHexFunc,
 }
 
 var pp = props.NewPathParser()

--- a/pkg/pipeline/template_engine/template_engine_funcs.go
+++ b/pkg/pipeline/template_engine/template_engine_funcs.go
@@ -17,7 +17,9 @@ limitations under the License.
 package template_engine
 
 import (
+	"bytes"
 	"crypto/sha256"
+	"encoding/hex"
 	"fmt"
 	"net/url"
 	"os"
@@ -26,6 +28,7 @@ import (
 	"strings"
 	"text/template"
 
+	"github.com/google/uuid"
 	"github.com/inhies/go-bytesize"
 	"github.com/rkosegi/yaml-toolkit/analytics"
 	"github.com/rkosegi/yaml-toolkit/common"
@@ -174,6 +177,21 @@ func sizeStrFmtFunc(format string, unit string, size float64) string {
 
 func sizeStrFmtLongFunc(format string, unit string, size float64) string {
 	return bytesize.New(size).Format(format, unit, true)
+}
+
+func uuidv4FromHexFunc(hexStr string) (string, error) {
+	var (
+		enc    []byte
+		err    error
+		uuidv4 uuid.UUID
+	)
+	if enc, err = hex.DecodeString(hexStr); err != nil {
+		return "", err
+	}
+	if uuidv4, err = uuid.NewRandomFromReader(bytes.NewReader(enc)); err != nil {
+		return "", err
+	}
+	return uuidv4.String(), nil
 }
 
 func regexNamedExtractFunc(pattern string, str string) (map[string]string, error) {

--- a/pkg/pipeline/template_engine/template_engine_test.go
+++ b/pkg/pipeline/template_engine/template_engine_test.go
@@ -391,6 +391,26 @@ func TestTemplateFuncUrlParseQuery(t *testing.T) {
 	assert.Error(t, err)
 }
 
+func TestTemplateFuncUuidV4FromHex(t *testing.T) {
+	var (
+		err    error
+		uuidv4 string
+	)
+	t.Run("invalid input", func(t *testing.T) {
+		_, err = uuidv4FromHexFunc("$%^")
+		assert.Error(t, err)
+	})
+	t.Run("not enough data", func(t *testing.T) {
+		_, err = uuidv4FromHexFunc("00991c17fb14a0d5c40685f30dd55b")
+		assert.Error(t, err)
+	})
+	t.Run("valid", func(t *testing.T) {
+		uuidv4, err = uuidv4FromHexFunc("00991c17fb14a0d5c40685f30dd55b21")
+		assert.NoError(t, err)
+		assert.Equal(t, "00991c17-fb14-40d5-8406-85f30dd55b21", uuidv4)
+	})
+}
+
 func TestTemplateFuncRegexNamedExtract(t *testing.T) {
 	var (
 		res map[string]string


### PR DESCRIPTION
Input must be valid hex string that decodes to 16 bytes exactly

Signed-off-by: Richard Kosegi <richard.kosegi@gmail.com>
